### PR TITLE
Fix installation error (no more html folder)

### DIFF
--- a/templateDetails.xml
+++ b/templateDetails.xml
@@ -17,7 +17,6 @@
 	
 	<files><!-- no need to change -->
 		<folder>css</folder>
-		<folder>html</folder>
 		<folder>images</folder>
 		<folder>js</folder>
 		<filename>component.php</filename>


### PR DESCRIPTION
Removed html folder because it doesn't exist as directory anymore and therefore leads to an error when installing the template!
