### PR TITLE
Added import.css to use with @import directives

### DIFF
--- a/css/imports.css
+++ b/css/imports.css
@@ -1,0 +1,2 @@
+/* Add your CSS @import rules after this line */
+

--- a/css/template.css.php
+++ b/css/template.css.php
@@ -41,6 +41,9 @@ function compress($buffer) {
 	return $buffer;
 }
 
+// imports.css
+require('imports.css');
+
 // normalize.css
 require('normalize.css');
 


### PR DESCRIPTION
In css @import has to be placed at the top of the stylesheet. But template.css.php compresses all stylesheets which lead to @imports that are located anywhere in the resulting stylesheet. This plays an important role when using e.g. GoogleFonts. When you put the @import in the template.css it won't load the font. 
